### PR TITLE
SPPoolObject modifications

### DIFF
--- a/sparrow/src/Classes/SPBitmapFont.m
+++ b/sparrow/src/Classes/SPBitmapFont.m
@@ -52,8 +52,6 @@
     return self;
 }
 
-SP_IMPLEMENT_MEMORY_POOL();
-
 @end
 
 // --- class implementation ------------------------------------------------------------------------

--- a/sparrow/src/Classes/SPMatrix.m
+++ b/sparrow/src/Classes/SPMatrix.m
@@ -220,8 +220,4 @@ static inline void setValues(SPMatrix *matrix, float a, float b, float c, float 
                                                      tx:_tx ty:_ty];
 }
 
-#pragma mark SPPoolObject
-
-SP_IMPLEMENT_MEMORY_POOL();
-
 @end

--- a/sparrow/src/Classes/SPPoint.m
+++ b/sparrow/src/Classes/SPPoint.m
@@ -178,8 +178,4 @@
     return [[[self class] allocWithZone:zone] initWithX:_x y:_y];
 }
 
-#pragma mark SPPoolObject
-
-SP_IMPLEMENT_MEMORY_POOL();
-
 @end

--- a/sparrow/src/Classes/SPPoolObject.h
+++ b/sparrow/src/Classes/SPPoolObject.h
@@ -11,71 +11,29 @@
 
 #import <Foundation/Foundation.h>
 
-@class SPPoolObject;
-
-/// Internal Helper class for `SPPoolObject`.
-@interface SPPoolInfo : NSObject
-{
-  @public
-    Class poolClass;
-    SPPoolObject *lastElement;
-}
-
-@end
-
-#ifndef DISABLE_MEMORY_POOLING
-
-  #define SP_IMPLEMENT_MEMORY_POOL()                        \
-    + (SPPoolInfo *)poolInfo                                \
-    {                                                       \
-        static SPPoolInfo *poolInfo = nil;                  \
-        static dispatch_once_t once;                        \
-        dispatch_once(&once, ^{                             \
-            poolInfo = [[SPPoolInfo alloc] init];           \
-        });                                                 \
-        return poolInfo;                                    \
-    }                                                       \
-
-#else
-
-  #define SP_IMPLEMENT_MEMORY_POOL()                        \
-    + (SPPoolInfo *)poolInfo                                \
-    {                                                       \
-        return nil;                                         \
-    }                                                       \
-
-#endif
+#define SP_POOL_OBJECT_MAX_CLASSES  512
+#define SP_POOL_OBJECT_IS_ATOMIC    0
 
 /** ------------------------------------------------------------------------------------------------
- 
- The SPPoolObject class is an alternative to the base class `NSObject` that manages a pool of 
+
+ The SPPoolObject class is an alternative to the base class `NSObject` that manages a pool of
  objects.
- 
- **ATTENTION:** Pooling is NOT thread-safe! If you use any Sparrow objects across multiple threads,
- you should not use SPPoolObject. To disable memory pooling completely, define 
- `DISABLE_MEMORY_POOLING` in the Sparrow project.
- 
+
  Subclasses of SPPoolObject do not deallocate object instances when the retain counter reaches
  zero. Instead, the objects stay in memory and will be re-used when a new instance of the object
- is requested. That way, object initialization is accelerated. You can release the memory of all 
+ is requested. That way, object initialization is accelerated. You can release the memory of all
  recycled objects anytime by calling the `purgePool` method.
- 
- Sparrow uses this class for `SPPoint`, `SPRectangle` and `SPMatrix`, as they are created very often 
- as helper objects.
- 
- To use memory pooling for another class, you just have to inherit from SPPoolObject and put
- the following macro somewhere in your implementation:
 
-  	SP_IMPLEMENT_MEMORY_POOL();
- 
-------------------------------------------------------------------------------------------------- */
+ Sparrow uses this class for `SPPoint`, `SPRectangle` and `SPMatrix`, as they are created very often
+ as helper objects.
+
+ To use memory pooling for another class, you just have to inherit from SPPoolObject.
+
+ ------------------------------------------------------------------------------------------------- */
 
 #ifndef DISABLE_MEMORY_POOLING
 
-@interface SPPoolObject : NSObject 
-
-/// The pool info structure needed to access the pool. Needs to be implemented in any inheriting class.
-+ (SPPoolInfo *)poolInfo;
+@interface SPPoolObject : NSObject
 
 /// Purge all unused objects.
 + (int)purgePool;
@@ -84,10 +42,7 @@
 
 #else
 
-@interface SPPoolObject : NSObject 
-
-/// Dummy implementation of SPPoolObject method to simplify switching between NSObject and SPPoolObject.
-+ (SPPoolInfo *)poolInfo;
+@interface SPPoolObject : NSObject
 
 /// Dummy implementation of SPPoolObject method to simplify switching between NSObject and SPPoolObject.
 + (int)purgePool;
@@ -95,3 +50,7 @@
 @end
 
 #endif
+
+// deprecated
+
+#define SP_IMPLEMENT_MEMORY_POOL()

--- a/sparrow/src/Classes/SPPoolObject.m
+++ b/sparrow/src/Classes/SPPoolObject.m
@@ -10,87 +10,152 @@
 //
 
 #import "SPPoolObject.h"
+#import "SPMacros.h"
+
+#import <libkern/OSAtomic.h>
 #import <malloc/malloc.h>
 #import <objc/runtime.h>
 
-#define COMPLAIN_MISSING_IMP @"Class %@ needs this code:\nSP_IMPLEMENT_MEMORY_POOL();" 
-
-@implementation SPPoolInfo
-// empty
-@end
-
 #ifndef DISABLE_MEMORY_POOLING
+
+// --- hash table ----------------------------------------------------------------------------------
+
+#define HASH_MASK (SP_POOL_OBJECT_MAX_CLASSES - 1)
+
+struct __SPPoolCachePair
+{
+    Class key;
+    OSQueueHead value;
+};
+typedef struct __SPPoolCachePair SPPoolCachePair;
+
+struct __SPPoolCache
+{
+    SPPoolCachePair table[SP_POOL_OBJECT_MAX_CLASSES];
+};
+typedef struct __SPPoolCache SPPoolCache;
+
+SP_INLINE SPPoolCache* getPoolCache(void)
+{
+    static SPPoolCache instance = (SPPoolCache){{ nil, OS_ATOMIC_QUEUE_INIT }};
+    return &instance;
+}
+
+SP_INLINE SPPoolCachePair* getValueForKey(SPPoolCache* hash, size_t key)
+{
+    return &hash->table[key & HASH_MASK];
+}
+
+SP_INLINE size_t generateKeyForClass(Class class)
+{
+    return (((size_t)class) & HASH_MASK);
+}
+
+SP_INLINE void addClassToCache(Class class)
+{
+    SPPoolCache *poolHash = getPoolCache();
+    size_t hashKey = generateKeyForClass(class);
+    poolHash->table[hashKey].key = class;
+}
+
+SP_INLINE OSQueueHead* getQueueWithClass(Class class)
+{
+    SPPoolCache *poolHash = getPoolCache();
+    size_t hashKey = generateKeyForClass(class);
+    OSQueueHead *queue = NULL;
+
+    SPPoolCachePair *poolValue = getValueForKey(poolHash, hashKey);
+    if (poolValue->key == class)
+        queue = &poolValue->value;
+
+    return queue;
+}
+
+// --- queue ---------------------------------------------------------------------------------------
+
+#define QUEUE_OFFSET        sizeof(Class)
+#define DEQUEUE(pool)       OSAtomicDequeue(pool, QUEUE_OFFSET)
+#define ENQUEUE(pool, obj)  OSAtomicEnqueue(pool, obj, QUEUE_OFFSET)
+
+// --- class implementation ------------------------------------------------------------------------
+
+#if SP_POOL_OBJECT_IS_ATOMIC
+    #define INCREMENT_32(var)    OSAtomicIncrement32Barrier(&var)
+    #define DECREMENT_32(var)    OSAtomicDecrement32Barrier(&var)
+    #define MEMORY_BARRIER()     OSMemoryBarrier()
+#else
+    #define INCREMENT_32(var)    (++ var)
+    #define DECREMENT_32(var)    (-- var)
+    #define MEMORY_BARRIER()
+#endif
+
+#define RETAIN_COUNT _refOrLink.ref
 
 @implementation SPPoolObject
 {
-    SPPoolObject *_poolPredecessor;
-    uint _retainCount;
+    union // since link is only used while in the queue
+    {
+        int32_t ref;
+        SPPoolObject *link;
+    }
+    _refOrLink;
+}
+
++ (void)initialize
+{
+    if (self == [SPPoolObject class])
+        return;
+
+    addClassToCache(self);
 }
 
 + (id)allocWithZone:(NSZone *)zone
 {
-  #if DEBUG
+  #if DEBUG && !SP_POOL_OBJECT_IS_ATOMIC
     // make sure that people don't use pooling from multiple threads
     static id thread = nil;
-    if (thread) NSAssert(thread == [NSThread currentThread], @"SPPoolObject is NOT thread safe!");
+    if (thread) NSAssert(thread == [NSThread currentThread], @"SPPoolObject is NOT thread safe! Must set SP_POOL_OBJECT_IS_ATOMIC to 1.");
     else thread = [NSThread currentThread];
   #endif
 
-    SPPoolInfo *poolInfo = [self poolInfo];
-    
-    if (poolInfo->lastElement)
+    OSQueueHead *poolQueue = getQueueWithClass(self);
+    SPPoolObject *object = DEQUEUE(poolQueue);
+
+    if (object)
     {
-        // recycle element, update poolInfo
-        SPPoolObject *object = poolInfo->lastElement;
-        poolInfo->lastElement = object->_poolPredecessor;
-        
-        // zero out memory. (do not overwrite isa & _poolPredecessor, thus the offset)
-        static size_t offset = sizeof(Class) + sizeof(SPPoolObject *);
+        // zero out memory. (do not overwrite isa, thus the offset)
+        static size_t offset = sizeof(Class);
         memset((char *)(id)object + offset, 0, malloc_size(object) - offset);
-        object->_retainCount = 1;
-        return object;
+        object->RETAIN_COUNT = 1;
     }
-    else 
+    else
     {
-        // first allocation
-        if (!poolInfo->poolClass)
-        {
-            poolInfo->poolClass = self;
-            poolInfo->lastElement = NULL;
-        }
-        else if (poolInfo->poolClass != self)
-        {
-            [NSException raise:NSGenericException format:COMPLAIN_MISSING_IMP, self];
-            return nil;
-        }
-        
         // pool is empty -> allocate
-        SPPoolObject *object = NSAllocateObject(self, 0, NULL);
-        object->_retainCount = 1;
-        return object;
+        object = NSAllocateObject(self, 0, NULL);
+        object->RETAIN_COUNT = 1;
     }
+
+    return object;
 }
 
 - (NSUInteger)retainCount
 {
-    return _retainCount;
+    MEMORY_BARRIER();
+    return RETAIN_COUNT;
 }
 
 - (instancetype)retain
 {
-    ++_retainCount;
+    INCREMENT_32(RETAIN_COUNT);
     return self;
 }
 
 - (oneway void)release
 {
-    --_retainCount;
-    
-    if (!_retainCount)
+    if (DECREMENT_32(RETAIN_COUNT) == 0)
     {
-        SPPoolInfo *poolInfo = [object_getClass(self) poolInfo];
-        self->_poolPredecessor = poolInfo->lastElement;
-        poolInfo->lastElement = self;
+        OSQueueHead *poolQueue = getQueueWithClass(object_getClass(self));
+        ENQUEUE(poolQueue, self);
     }
 }
 
@@ -102,24 +167,17 @@
 
 + (int)purgePool
 {
-    SPPoolInfo *poolInfo = [self poolInfo];    
-    SPPoolObject *lastElement;    
-    
-    int count=0;
-    while ((lastElement = poolInfo->lastElement))
+    OSQueueHead *poolQueue = getQueueWithClass(self);
+    SPPoolObject *lastElement;
+
+    int count = 0;
+    while ((lastElement = DEQUEUE(poolQueue)))
     {
-        ++count;        
-        poolInfo->lastElement = lastElement->_poolPredecessor;
+        ++count;
         [lastElement purge];
     }
-    
-    return count;
-}
 
-+ (SPPoolInfo *)poolInfo
-{
-    [NSException raise:NSGenericException format:COMPLAIN_MISSING_IMP, self];
-    return NULL;
+    return count;
 }
 
 @end
@@ -127,11 +185,6 @@
 #else
 
 @implementation SPPoolObject
-
-+ (SPPoolInfo *)poolInfo 
-{
-    return nil;
-}
 
 + (int)purgePool
 {

--- a/sparrow/src/Classes/SPRectangle.m
+++ b/sparrow/src/Classes/SPRectangle.m
@@ -179,8 +179,4 @@
     return [[[self class] allocWithZone:zone] initWithX:_x y:_y width:_width height:_height];
 }
 
-#pragma mark SPPoolObject
-
-SP_IMPLEMENT_MEMORY_POOL();
-
 @end


### PR DESCRIPTION
optionally threadsafe, no longer requires subclasses to implement the
SP_IMPLEMENT_MEMORY_POOL() macro, uses a static hash table of queues
instead
